### PR TITLE
Bump maximum KSP version to 1.2.99

### DIFF
--- a/CorrectCoL.version
+++ b/CorrectCoL.version
@@ -12,6 +12,6 @@
 	{
 		"MAJOR":1,
 		"MINOR":2,
-		"PATCH":0
+		"PATCH":99
 	}
 }


### PR DESCRIPTION
Assuming that SQUAD will play nice with their minor version number
updates, we can allow installation of this plugin for any KSP minor
version of 1.2.